### PR TITLE
Corrected typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You'll also need to follow the instructions for setting up a Sonatype Jira accou
 
 ### GPG key generation
 
-Here's a terse summary of the GPG commands you'll need to generate and publish a key for signing your artifacts. For the full version, see https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven:
+Here's a terse summary of the GPG commands you'll need to generate and publish a key for signing your artifacts. For the full version, see https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven
 
     # is GPG installed?
     gpg --version 


### PR DESCRIPTION
There was a superfluous colon following the link to the GPG documentation link which broke the link when rendered on Github.
