### PR TITLE
Fixed settings.xml

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -7,12 +7,12 @@
 
 		<!-- Local Nexus - for testing: -->
 		<server>
-			<id>workdocx-nexus-snapshots</id>
+			<id>localhost-nexus-snapshots</id>
 			<username>deployment</username>
 			<password>deployment123</password>
 		</server>
 		<server>
-			<id>workdocx-nexus-release</id>
+			<id>localhost-nexus-staging</id>
 			<username>deployment</username>
 			<password>deployment123</password>
 		</server>


### PR DESCRIPTION
The id's for the servers defined in the POM and settings.xml were different, however, they are required to be the same.
